### PR TITLE
make dotIndicator to respect visible value

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/presentation/BottomTabPresenter.java
@@ -103,6 +103,7 @@ public class BottomTabPresenter {
     }
 
     private void applyDotIndicator(int tabIndex, DotIndicatorOptions dotIndicator) {
+        if(dotIndicator.visible.isFalse()) return;
         AHNotification.Builder builder = new AHNotification.Builder()
                 .setText("")
                 .setBackgroundColor(dotIndicator.color.get(null))

--- a/lib/ios/RNNBasePresenter.h
+++ b/lib/ios/RNNBasePresenter.h
@@ -1,4 +1,5 @@
 #import "RNNNavigationOptions.h"
+#import "RNNReactComponentRegistry.h"
 
 typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
@@ -8,9 +9,13 @@ typedef void (^RNNReactViewReadyCompletionBlock)(void);
 
 @property(nonatomic, strong) NSString *boundComponentId;
 
-@property(nonatomic, strong) RNNNavigationOptions * defaultOptions;
+@property(nonatomic, strong) RNNNavigationOptions* defaultOptions;
+
+@property(nonatomic, strong) RNNReactComponentRegistry* componentRegistry;
 
 - (instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions;
+
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry defaultOptions:(RNNNavigationOptions *)defaultOptions;
 
 - (void)setDefaultOptions:(RNNNavigationOptions *)defaultOptions;
 

--- a/lib/ios/RNNBasePresenter.m
+++ b/lib/ios/RNNBasePresenter.m
@@ -12,10 +12,16 @@
 @end
 @implementation RNNBasePresenter
 
--(instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions {
+- (instancetype)initWithDefaultOptions:(RNNNavigationOptions *)defaultOptions {
     self = [super init];
     _defaultOptions = defaultOptions;
     self.dotIndicatorPresenter = [[RNNDotIndicatorPresenter alloc] initWithDefaultOptions:_defaultOptions];
+    return self;
+}
+
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry defaultOptions:(RNNNavigationOptions *)defaultOptions {
+    self = [self initWithDefaultOptions:defaultOptions];
+    _componentRegistry = componentRegistry;
     return self;
 }
 

--- a/lib/ios/RNNComponentPresenter.h
+++ b/lib/ios/RNNComponentPresenter.h
@@ -4,8 +4,6 @@
 
 @interface RNNComponentPresenter : RNNBasePresenter
 
-- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry:(RNNNavigationOptions *)defaultOptions;
-
 - (void)renderComponents:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock;
 
 @property (nonatomic, strong) RNNNavigationButtons* navigationButtons;

--- a/lib/ios/RNNComponentPresenter.m
+++ b/lib/ios/RNNComponentPresenter.m
@@ -5,26 +5,23 @@
 #import "RNNTitleViewHelper.h"
 #import "UIViewController+LayoutProtocol.h"
 #import "RNNReactTitleView.h"
+#import "TopBarTitlePresenter.h"
 
-@interface RNNComponentPresenter() {
-	RNNReactTitleView* _customTitleView;
-	RNNTitleViewHelper* _titleViewHelper;
-	RNNReactComponentRegistry* _componentRegistry;
+
+@implementation RNNComponentPresenter {
+    TopBarTitlePresenter* _topBarTitlePresenter;
 }
 
-@end
-
-@implementation RNNComponentPresenter
-
-- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry:(RNNNavigationOptions *)defaultOptions {
-	self = [self initWithDefaultOptions:defaultOptions];
-	_componentRegistry = componentRegistry;
+- (instancetype)initWithComponentRegistry:(RNNReactComponentRegistry *)componentRegistry defaultOptions:(RNNNavigationOptions *)defaultOptions {
+	self = [super initWithComponentRegistry:componentRegistry defaultOptions:defaultOptions];
+	_topBarTitlePresenter = [[TopBarTitlePresenter alloc] initWithComponentRegistry:componentRegistry defaultOptions:defaultOptions];
 	return self;
 }
 
 - (void)bindViewController:(id)boundViewController {
 	[super bindViewController:boundViewController];
-	_navigationButtons = [[RNNNavigationButtons alloc] initWithViewController:self.boundViewController componentRegistry:_componentRegistry];
+	[_topBarTitlePresenter bindViewController:boundViewController];
+	_navigationButtons = [[RNNNavigationButtons alloc] initWithViewController:boundViewController componentRegistry:self.componentRegistry];
 }
 
 - (void)componentDidAppear {
@@ -32,7 +29,7 @@
     if ([component respondsToSelector:@selector(componentDidAppear)]) {
         [component componentDidAppear];
     }
-    [_customTitleView componentDidAppear];
+    [_topBarTitlePresenter componentDidAppear];
     [_navigationButtons componentDidAppear];
 }
 
@@ -42,7 +39,7 @@
         [component componentDidDisappear];
     }
     
-    [_customTitleView componentDidDisappear];
+    [_topBarTitlePresenter componentDidDisappear];
     [_navigationButtons componentDidDisappear];
 }
 
@@ -56,7 +53,6 @@
 	UIViewController* viewController = self.boundViewController;
 	RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
 	[viewController setBackgroundImage:[withDefault.backgroundImage getWithDefaultValue:nil]];
-	[viewController setNavigationItemTitle:[withDefault.topBar.title.text getWithDefaultValue:nil]];
 	[viewController setTopBarPrefersLargeTitle:[withDefault.topBar.largeTitle.visible getWithDefaultValue:NO]];
 	[viewController setTabBarItemBadgeColor:[withDefault.bottomTab.badgeColor getWithDefaultValue:nil]];
 	[viewController setStatusBarBlur:[withDefault.statusBar.blur getWithDefaultValue:NO]];
@@ -75,8 +71,8 @@
 		}
 		[viewController setSearchBarWithPlaceholder:[withDefault.topBar.searchBarPlaceholder getWithDefaultValue:@""] hideNavBarOnFocusSearchBar:hideNavBarOnFocusSearchBar];
 	}
-
-	[self setTitleViewWithSubtitle:withDefault];
+	
+	[_topBarTitlePresenter applyOptions:withDefault.topBar];
 }
 
 - (void)applyOptionsOnInit:(RNNNavigationOptions *)options {
@@ -96,7 +92,6 @@
     [super mergeOptions:options resolvedOptions:currentOptions];
 	RNNNavigationOptions * withDefault	= (RNNNavigationOptions *) [[currentOptions overrideOptions:options] withDefault:[self defaultOptions]];
 	UIViewController* viewController = self.boundViewController;
-	[self removeTitleComponentIfNeeded:options];
 
 	if (options.backgroundImage.hasValue) {
 		[viewController setBackgroundImage:options.backgroundImage.get];
@@ -120,10 +115,6 @@
 	
 	if (options.topBar.drawBehind.hasValue) {
 		[viewController setDrawBehindTopBar:options.topBar.drawBehind.get];
-	}
-	
-	if (options.topBar.title.text.hasValue) {
-		[viewController setNavigationItemTitle:options.topBar.title.text.get];
 	}
 	
 	if (options.topBar.largeTitle.visible.hasValue) {
@@ -167,68 +158,17 @@
 		RCTRootView* rootView = (RCTRootView*)viewController.view;
 		rootView.passThroughTouches = !options.overlay.interceptTouchOutside.get;
 	}
-
-	if (options.topBar.title.component.name.hasValue) {
-		[self setCustomNavigationTitleView:options perform:nil];
-	}
-
-	[self setTitleViewWithSubtitle:withDefault];
-}
-
-- (void)removeTitleComponentIfNeeded:(RNNNavigationOptions *)options {
-	if (options.topBar.title.text.hasValue) {
-        [_customTitleView componentDidDisappear];
-		[_customTitleView removeFromSuperview];
-		_customTitleView = nil;
-	}
+	
+	[_topBarTitlePresenter mergeOptions:options.topBar resolvedOptions:currentOptions.topBar];
 }
 
 - (void)renderComponents:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {
     RNNNavigationOptions *withDefault = [options withDefault:[self defaultOptions]];
-	[self setCustomNavigationTitleView:withDefault perform:readyBlock];
+    [_topBarTitlePresenter renderComponents:withDefault.topBar perform:readyBlock];
 }
 
-- (void)setCustomNavigationTitleView:(RNNNavigationOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {
-	UIViewController<RNNLayoutProtocol>* viewController = self.boundViewController;
-	if (![options.topBar.title.component.waitForRender getWithDefaultValue:NO] && readyBlock) {
-		readyBlock();
-		readyBlock = nil;
-	}
-	
-	if (options.topBar.title.component.name.hasValue) {
-        _customTitleView = (RNNReactTitleView *)[_componentRegistry createComponentIfNotExists:options.topBar.title.component parentComponentId:viewController.layoutInfo.componentId componentType:RNNComponentTypeTopBarTitle reactViewReadyBlock:readyBlock];
-		_customTitleView.backgroundColor = UIColor.clearColor;
-		NSString* alignment = [options.topBar.title.component.alignment getWithDefaultValue:@""];
-		[_customTitleView setAlignment:alignment inFrame:viewController.navigationController.navigationBar.frame];
-		[_customTitleView layoutIfNeeded];
-		
-		viewController.navigationItem.titleView = nil;
-		viewController.navigationItem.titleView = _customTitleView;
-        [_customTitleView componentDidAppear];
-	} else {
-		[_customTitleView removeFromSuperview];
-		if (readyBlock) {
-			readyBlock();
-		}
-	}
-}
-
-- (void)setTitleViewWithSubtitle:(RNNNavigationOptions *)options {
-	if (!_customTitleView && ![options.topBar.largeTitle.visible getWithDefaultValue:NO]) {
-		_titleViewHelper = [[RNNTitleViewHelper alloc] initWithTitleViewOptions:options.topBar.title subTitleOptions:options.topBar.subtitle viewController:self.boundViewController];
-
-		if (options.topBar.title.text.hasValue) {
-			[_titleViewHelper setTitleOptions:options.topBar.title];
-		}
-		if (options.topBar.subtitle.text.hasValue) {
-			[_titleViewHelper setSubtitleOptions:options.topBar.subtitle];
-		}
-
-		[_titleViewHelper setup];
-	}
-}
 
 - (void)dealloc {
-	[_componentRegistry clearComponentsForParentId:self.boundComponentId];
+	[self.componentRegistry clearComponentsForParentId:self.boundComponentId];
 }
 @end

--- a/lib/ios/RNNControllerFactory.m
+++ b/lib/ios/RNNControllerFactory.m
@@ -114,7 +114,7 @@
 - (UIViewController *)createComponent:(RNNLayoutNode*)node {
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
 	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];;
-	RNNComponentPresenter* presenter = [[RNNComponentPresenter alloc] initWithComponentRegistry:_componentRegistry:_defaultOptions];
+	RNNComponentPresenter* presenter = [[RNNComponentPresenter alloc] initWithComponentRegistry:_componentRegistry defaultOptions:_defaultOptions];
 	
 	RNNComponentViewController* component = [[RNNComponentViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:_creator eventEmitter:_eventEmitter presenter:presenter options:options defaultOptions:_defaultOptions];
 	
@@ -193,7 +193,7 @@
 	RNNLayoutInfo* layoutInfo = [[RNNLayoutInfo alloc] initWithNode:node];
 	RNNNavigationOptions* options = [[RNNNavigationOptions alloc] initWithDict:node.data[@"options"]];
 
-	RNNSideMenuChildVC *sideMenuChild = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:[[RNNComponentPresenter alloc] initWithComponentRegistry:_componentRegistry:_defaultOptions] eventEmitter:_eventEmitter childViewController:childVc type:type];
+	RNNSideMenuChildVC *sideMenuChild = [[RNNSideMenuChildVC alloc] initWithLayoutInfo:layoutInfo creator:_creator options:options defaultOptions:_defaultOptions presenter:[[RNNComponentPresenter alloc] initWithComponentRegistry:_componentRegistry defaultOptions:_defaultOptions] eventEmitter:_eventEmitter childViewController:childVc type:type];
 	
 	return sideMenuChild;
 }

--- a/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
+++ b/lib/ios/ReactNativeNavigation.xcodeproj/project.pbxproj
@@ -184,6 +184,8 @@
 		50570BEA2063E09B006A1B5C /* RNNTitleViewHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 50570BE82063E09B006A1B5C /* RNNTitleViewHelper.h */; };
 		50570BEB2063E09B006A1B5C /* RNNTitleViewHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 50570BE92063E09B006A1B5C /* RNNTitleViewHelper.m */; };
 		505963F722676A0000EBB63C /* RNNLayoutManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 505963F622676A0000EBB63C /* RNNLayoutManagerTest.m */; };
+		505C640223E074860078AFC0 /* TopBarTitlePresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 505C640023E074860078AFC0 /* TopBarTitlePresenter.h */; };
+		505C640323E074860078AFC0 /* TopBarTitlePresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 505C640123E074860078AFC0 /* TopBarTitlePresenter.m */; };
 		505EDD32214E4BE80071C7DE /* RNNNavigationControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 505EDD31214E4BE80071C7DE /* RNNNavigationControllerTest.m */; };
 		505EDD34214E7B7B0071C7DE /* RNNLeafProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 505EDD33214E7A6A0071C7DE /* RNNLeafProtocol.h */; };
 		505EDD3C214FA8000071C7DE /* RNNComponentPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 505EDD3A214FA8000071C7DE /* RNNComponentPresenter.h */; };
@@ -572,6 +574,8 @@
 		50570BE82063E09B006A1B5C /* RNNTitleViewHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNTitleViewHelper.h; sourceTree = "<group>"; };
 		50570BE92063E09B006A1B5C /* RNNTitleViewHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNTitleViewHelper.m; sourceTree = "<group>"; };
 		505963F622676A0000EBB63C /* RNNLayoutManagerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNLayoutManagerTest.m; sourceTree = "<group>"; };
+		505C640023E074860078AFC0 /* TopBarTitlePresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TopBarTitlePresenter.h; sourceTree = "<group>"; };
+		505C640123E074860078AFC0 /* TopBarTitlePresenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TopBarTitlePresenter.m; sourceTree = "<group>"; };
 		505EDD31214E4BE80071C7DE /* RNNNavigationControllerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNNNavigationControllerTest.m; sourceTree = "<group>"; };
 		505EDD33214E7A6A0071C7DE /* RNNLeafProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNLeafProtocol.h; sourceTree = "<group>"; };
 		505EDD3A214FA8000071C7DE /* RNNComponentPresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNComponentPresenter.h; sourceTree = "<group>"; };
@@ -1086,6 +1090,14 @@
 				651E1F8C21FD642100DFEA19 /* RNNSplitViewControllerPresenter.m */,
 				30987E66AA7AB38E7370F8C8 /* RNNDotIndicatorPresenter.m */,
 				309878B02F15ECDD1A286722 /* RNNDotIndicatorPresenter.h */,
+				50CED447239EA56100C42EE2 /* TopBarPresenterCreator.h */,
+				50CED448239EA56100C42EE2 /* TopBarPresenterCreator.m */,
+				50CED44B239EA78700C42EE2 /* TopBarAppearancePresenter.h */,
+				50CED44C239EA78700C42EE2 /* TopBarAppearancePresenter.m */,
+				50CED44F239F9DFC00C42EE2 /* TopBarPresenter.h */,
+				50CED450239F9DFC00C42EE2 /* TopBarPresenter.m */,
+				505C640023E074860078AFC0 /* TopBarTitlePresenter.h */,
+				505C640123E074860078AFC0 /* TopBarTitlePresenter.m */,
 			);
 			name = Presenters;
 			sourceTree = "<group>";
@@ -1143,12 +1155,6 @@
 				50570BE92063E09B006A1B5C /* RNNTitleViewHelper.m */,
 				501CD31D214A5B6900A6E225 /* RNNLayoutInfo.h */,
 				501CD31E214A5B6900A6E225 /* RNNLayoutInfo.m */,
-				50CED447239EA56100C42EE2 /* TopBarPresenterCreator.h */,
-				50CED448239EA56100C42EE2 /* TopBarPresenterCreator.m */,
-				50CED44B239EA78700C42EE2 /* TopBarAppearancePresenter.h */,
-				50CED44C239EA78700C42EE2 /* TopBarAppearancePresenter.m */,
-				50CED44F239F9DFC00C42EE2 /* TopBarPresenter.h */,
-				50CED450239F9DFC00C42EE2 /* TopBarPresenter.m */,
 				501E0215213E7EA3003365C5 /* RNNReactView.h */,
 				501E0216213E7EA3003365C5 /* RNNReactView.m */,
 				503A8A1723BCB2ED0094D1C4 /* RNNReactButtonView.h */,
@@ -1466,6 +1472,7 @@
 				5049593E216F5D73006D2B81 /* BoolParser.h in Headers */,
 				E5F6C3A522DB4D0F0093C2CE /* UIViewController+Utils.h in Headers */,
 				50C4A496206BDDBB00DB292E /* RNNSubtitleOptions.h in Headers */,
+				505C640223E074860078AFC0 /* TopBarTitlePresenter.h in Headers */,
 				5039559B2174867000B0A663 /* DoubleParser.h in Headers */,
 				E8AEDB3C1F55A1C2000F5A6A /* RNNElementView.h in Headers */,
 				E8E518321F83B3E0000467AC /* RNNUtils.h in Headers */,
@@ -1730,6 +1737,7 @@
 				50395594217485B000B0A663 /* Double.m in Sources */,
 				504AFE751FFFF0540076E904 /* RNNTopTabsOptions.m in Sources */,
 				50175CD2207A2AA1004FE91B /* RNNComponentOptions.m in Sources */,
+				505C640323E074860078AFC0 /* TopBarTitlePresenter.m in Sources */,
 				50E02BDC21A6EE7900A43942 /* SideMenuOpenGestureModeParser.m in Sources */,
 				7BEF0D1D1E43771B003E96B0 /* RNNLayoutNode.m in Sources */,
 				7BA500781E254908001B9E1B /* RNNSplashScreen.m in Sources */,

--- a/lib/ios/TopBarTitlePresenter.h
+++ b/lib/ios/TopBarTitlePresenter.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+#import "RNNNavigationOptions.h"
+#import "UIViewController+LayoutProtocol.h"
+
+@interface TopBarTitlePresenter : RNNBasePresenter
+
+- (void)applyOptions:(RNNTopBarOptions *)options;
+
+- (void)mergeOptions:(RNNTopBarOptions *)options resolvedOptions:(RNNTopBarOptions *)resolvedOptions;
+
+- (void)setCustomNavigationTitleView:(RNNTopBarOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock;
+
+@end

--- a/lib/ios/TopBarTitlePresenter.m
+++ b/lib/ios/TopBarTitlePresenter.m
@@ -1,0 +1,89 @@
+#import "TopBarTitlePresenter.h"
+#import "UIViewController+RNNOptions.h"
+#import "RNNTitleViewHelper.h"
+#import "RNNReactTitleView.h"
+
+@implementation TopBarTitlePresenter {
+    RNNReactTitleView* _customTitleView;
+    RNNTitleViewHelper* _titleViewHelper;
+}
+
+- (void)applyOptions:(RNNTopBarOptions *)options {
+	[self updateTitleWithOptions:options];
+}
+
+- (void)updateTitleWithOptions:(RNNTopBarOptions *)options {
+    if (options.title.component.hasValue) {
+        [self setCustomNavigationTitleView:options perform:nil];
+    }else if (options.subtitle.text.hasValue) {
+        [self setTitleViewWithSubtitle:options];
+    }else if (options.title.text.hasValue) {
+        [self removeTitleComponents];
+        self.boundViewController.navigationItem.title = options.title.text.get;
+    }
+}
+
+- (void)mergeOptions:(RNNTopBarOptions *)options resolvedOptions:(RNNTopBarOptions *)resolvedOptions {
+    [self updateTitleWithOptions:options];
+}
+
+- (void)setTitleViewWithSubtitle:(RNNTopBarOptions *)options {
+	if (!_customTitleView && ![options.largeTitle.visible getWithDefaultValue:NO]) {
+		_titleViewHelper = [[RNNTitleViewHelper alloc] initWithTitleViewOptions:options.title subTitleOptions:options.subtitle viewController:self.boundViewController];
+
+		if (options.title.text.hasValue) {
+			[_titleViewHelper setTitleOptions:options.title];
+		}
+		if (options.subtitle.text.hasValue) {
+			[_titleViewHelper setSubtitleOptions:options.subtitle];
+		}
+
+		[_titleViewHelper setup];
+	}
+}
+
+- (void)renderComponents:(RNNTopBarOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {
+    [self setCustomNavigationTitleView:options perform:readyBlock];
+}
+
+- (void)setCustomNavigationTitleView:(RNNTopBarOptions *)options perform:(RNNReactViewReadyCompletionBlock)readyBlock {
+    UIViewController<RNNLayoutProtocol>* viewController = self.boundViewController;
+    if (![options.title.component.waitForRender getWithDefaultValue:NO] && readyBlock) {
+        readyBlock();
+        readyBlock = nil;
+    }
+    
+    if (options.title.component.name.hasValue) {
+        _customTitleView = (RNNReactTitleView *)[self.componentRegistry createComponentIfNotExists:options.title.component parentComponentId:viewController.layoutInfo.componentId componentType:RNNComponentTypeTopBarTitle reactViewReadyBlock:readyBlock];
+        _customTitleView.backgroundColor = UIColor.clearColor;
+        NSString* alignment = [options.title.component.alignment getWithDefaultValue:@""];
+        [_customTitleView setAlignment:alignment inFrame:viewController.navigationController.navigationBar.frame];
+        [_customTitleView layoutIfNeeded];
+        
+        viewController.navigationItem.titleView = nil;
+        viewController.navigationItem.titleView = _customTitleView;
+        [_customTitleView componentDidAppear];
+    } else {
+        [_customTitleView removeFromSuperview];
+        if (readyBlock) {
+            readyBlock();
+        }
+    }
+}
+
+- (void)removeTitleComponents {
+    [_customTitleView componentDidDisappear];
+    [_customTitleView removeFromSuperview];
+    _customTitleView = nil;
+    self.boundViewController.navigationItem.titleView = nil;
+}
+
+- (void)componentDidAppear {
+    [_customTitleView componentDidAppear];
+}
+
+- (void)componentDidDisappear {
+    [_customTitleView componentDidDisappear];
+}
+
+@end

--- a/playground/ios/NavigationIOS12Tests/RNNRootViewControllerTest.m
+++ b/playground/ios/NavigationIOS12Tests/RNNRootViewControllerTest.m
@@ -49,7 +49,7 @@
 	layoutInfo.componentId = self.componentId;
 	layoutInfo.name = self.pageName;
 	
-	id presenter = [OCMockObject partialMockForObject:[[RNNComponentPresenter alloc] init]];
+	id presenter = [OCMockObject partialMockForObject:[[RNNComponentPresenter alloc] initWithComponentRegistry:nil defaultOptions:nil]];
 	self.uut = [[RNNComponentViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:self.creator eventEmitter:self.emitter presenter:presenter options:self.options defaultOptions:nil];
 }
 

--- a/playground/ios/NavigationTests/RNNCommandsHandlerTest.m
+++ b/playground/ios/NavigationTests/RNNCommandsHandlerTest.m
@@ -131,7 +131,7 @@
 	RNNLayoutInfo* layoutInfo = [RNNLayoutInfo new];
 	RNNTestRootViewCreator* creator = [[RNNTestRootViewCreator alloc] init];
 	
-	RNNComponentPresenter* presenter = [[RNNComponentPresenter alloc] init];
+	RNNComponentPresenter* presenter = [[RNNComponentPresenter alloc] initWithComponentRegistry:nil defaultOptions:nil];
 	RNNComponentViewController* vc = [[RNNComponentViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:creator eventEmitter:nil presenter:presenter options:initialOptions defaultOptions:nil];
 	
 	RNNStackController* nav = [[RNNStackController alloc] initWithLayoutInfo:nil creator:creator options:[[RNNNavigationOptions alloc] initEmptyOptions] defaultOptions:nil presenter:[[RNNStackPresenter alloc] init] eventEmitter:nil childViewControllers:@[vc]];
@@ -154,7 +154,7 @@
 	RNNNavigationOptions* initialOptions = [[RNNNavigationOptions alloc] initWithDict:@{}];
 	initialOptions.topBar.title.text = [[Text alloc] initWithValue:@"the title"];
 	
-	RNNComponentPresenter* presenter = [[RNNComponentPresenter alloc] init];
+	RNNComponentPresenter* presenter = [[RNNComponentPresenter alloc] initWithComponentRegistry:nil defaultOptions:nil];
 	RNNComponentViewController* vc = [[RNNComponentViewController alloc] initWithLayoutInfo:nil rootViewCreator:[[RNNTestRootViewCreator alloc] init] eventEmitter:nil presenter:presenter options:initialOptions defaultOptions:nil];
 	
 	__unused RNNStackController* nav = [[RNNStackController alloc] initWithRootViewController:vc];

--- a/playground/ios/NavigationTests/RNNComponentPresenterTest.m
+++ b/playground/ios/NavigationTests/RNNComponentPresenterTest.m
@@ -21,7 +21,7 @@
 - (void)setUp {
     [super setUp];
 	self.componentRegistry = [OCMockObject partialMockForObject:[RNNReactComponentRegistry new]];
-	self.uut = [[RNNComponentPresenter alloc] initWithComponentRegistry:self.componentRegistry:[[RNNNavigationOptions alloc] initEmptyOptions]];
+	self.uut = [[RNNComponentPresenter alloc] initWithComponentRegistry:self.componentRegistry defaultOptions:[[RNNNavigationOptions alloc] initEmptyOptions]];
 	self.boundViewController = [OCMockObject partialMockForObject:[RNNComponentViewController new]];
 	[self.uut bindViewController:self.boundViewController];
 	self.options = [[RNNNavigationOptions alloc] initEmptyOptions];

--- a/playground/ios/NavigationTests/RNNRootViewControllerTest.m
+++ b/playground/ios/NavigationTests/RNNRootViewControllerTest.m
@@ -49,7 +49,7 @@
 	layoutInfo.componentId = self.componentId;
 	layoutInfo.name = self.pageName;
 	
-	id presenter = [OCMockObject partialMockForObject:[[RNNComponentPresenter alloc] init]];
+	id presenter = [OCMockObject partialMockForObject:[[RNNComponentPresenter alloc] initWithComponentRegistry:nil defaultOptions:nil]];
 	self.uut = [[RNNComponentViewController alloc] initWithLayoutInfo:layoutInfo rootViewCreator:self.creator eventEmitter:self.emitter presenter:presenter options:self.options defaultOptions:nil];
 }
 
@@ -108,7 +108,7 @@
 	XCTAssertTrue([self.uut prefersStatusBarHidden]);
 }
 
-- (void)testTitle_string{
+- (void)testTitle_string {
 	NSString* title =@"some title";
 	self.options.topBar.title.text = [[Text alloc] initWithValue:title];
 


### PR DESCRIPTION
In Android dotIndicator with initial value of ```visible: false``` is not respected and the dot appears in any case. In iOS works as expected.

This patch fixes the problem by introducing a simple if condition.